### PR TITLE
Fix: Improve mobile layout by dynamically setting viewport height

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,6 +645,13 @@
         document.addEventListener('DOMContentLoaded', () => {
             const app = new JunaidAI();
             app.init();
+
+            const setAppHeight = () => {
+                const doc = document.documentElement;
+                doc.style.setProperty('--app-height', `${window.innerHeight}px`);
+            };
+            window.addEventListener('resize', setAppHeight);
+            setAppHeight();
         });
 
         class JunaidAI {


### PR DESCRIPTION
- The three-dot menu was getting cut off and the chat input field was partially hidden on mobile devices.
- This was caused by using `100vh`, which doesn't account for the mobile browser's UI elements.
- Added a script to dynamically set the `--app-height` CSS variable to `window.innerHeight` on load and resize, ensuring the app container uses the correct height.